### PR TITLE
Bump build number; fix license type

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,6 @@ package:
   name: xlrd
   version: {{ version }}
 
-
 source:
   url: https://pypi.io/packages/source/x/xlrd/xlrd-{{ version }}.tar.gz
   sha256: f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88
@@ -13,11 +12,12 @@ build:
   number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
-
 requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
@@ -28,7 +28,7 @@ test:
 
 about:
   home: 'http://www.python-excel.org/'
-  license: "BSD 3-Clause and BSD with advertising"
+  license: "BSD-3-Clause AND BSD-4-Clause"
   license_family: BSD
   license_file: LICENSE
   summary: 'Library for developers to extract data from Microsoft Excel (tm) spreadsheet files'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 1
-  noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,12 +26,12 @@ test:
     - test.xls
 
 about:
-  home: 'http://www.python-excel.org/'
+  home: 'https://www.python-excel.org/'
   license: "BSD-3-Clause AND BSD-4-Clause"
   license_family: BSD
   license_file: LICENSE
   summary: 'Library for developers to extract data from Microsoft Excel (tm) spreadsheet files'
-  doc_url: http://xlrd.readthedocs.io/en/latest/
+  doc_url: https://xlrd.readthedocs.io/en/latest/
   dev_url: https://github.com/python-excel/xlrd/
   description: |
     xlrd is a library for reading data and formatting information from Excel files,


### PR DESCRIPTION
Nothing has changed upstream for v2.0.1 since its release (Dec 11, 2020). Rebuilding (with bump of the build number) because we are no longer supporting `noarch` builds; rebuilding to be arch-specific.

Changelog: https://github.com/python-excel/xlrd/blob/master/CHANGELOG.rst#201-11-december-2020
License: https://github.com/python-excel/xlrd/blob/master/LICENSE

Requirements:
https://github.com/python-excel/xlrd/blob/master/setup.py#L39

Actions:
- Remove `noarch` python
- Updated the license type to be SPDX-compliant
- Update host deps to include `setuptools` and `wheel`
