### PR TITLE
PKG-9899 - Bumping xlrd-feedstock to version 2.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,17 @@
-{% set version = "2.0.1" %}
+{% set version = "2.0.2" %}
 
 package:
   name: xlrd
   version: {{ version }}
 
-
 source:
-  url: https://pypi.io/packages/source/x/xlrd/xlrd-{{ version }}.tar.gz
-  sha256: f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88
+  url: https://pypi.org/packages/source/x/xlrd/xlrd-{{ version }}.tar.gz
+  sha256: 08b5e25de58f21ce71dc7db3b3b8106c1fa776f3024c54e45b45b374e89234c9
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-
 
 requirements:
   host:
@@ -43,6 +41,8 @@ about:
     xlrd is a library for reading data and formatting information from Excel files,
     whether they are .xls or .xlsx files.
 
+
+
 extra:
   recipe-maintainers:
-   - cokelaer
+    - cokelaer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,12 @@
 {% set version = "2.0.2" %}
+{% set name = "xlrd" %}
 
 package:
-  name: xlrd
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/x/xlrd/xlrd-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 08b5e25de58f21ce71dc7db3b3b8106c1fa776f3024c54e45b45b374e89234c9
 
 build:
@@ -30,13 +31,13 @@ test:
     - test.xls
 
 about:
-  home: https://www.python-excel.org/
+  home: https://www.python-excel.org
   license: BSD-3-Clause AND BSD-Advertising-Acknowledgement
   license_family: BSD
   license_file: LICENSE
   summary: Library for developers to extract data from Microsoft Excel (tm) spreadsheet files
-  doc_url: https://xlrd.readthedocs.io/en/latest/
-  dev_url: https://github.com/python-excel/xlrd/
+  doc_url: https://xlrd.readthedocs.io
+  dev_url: https://github.com/python-excel/xlrd
   description: |
     xlrd is a library for reading data and formatting information from Excel files,
     whether they are .xls or .xlsx files.


### PR DESCRIPTION
xlrd 2.0.2 

**Destination channel:** Defaults

### Links

- [PKG-9899]
- dev_url:        https://github.com/python-excel/xlrd//tree/2.0.2
- conda_forge:    https://github.com/conda-forge/xlrd-feedstock
- pypi:           https://pypi.org/project/xlrd/2.0.2
- pypi inspector: https://inspector.pypi.io/project/xlrd/2.0.2

### Explanation of changes:

- new version number

[PKG-9899]: https://anaconda.atlassian.net/browse/PKG-9899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ